### PR TITLE
Add BM25-based context aware chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,12 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "streamlit>=1.47.1", 
+    "streamlit>=1.47.1",
     "openai>=1.98.0",
     "polars>=1.32.3",
     "tiktoken>=0.11.0",
     "numpy>=2.3.2",
+    "rank-bm25>=0.2.2",
     "streamlit-agraph>=0.0.45",
     "networkx>=3.3",
 ]

--- a/src/lib/bm25_search.py
+++ b/src/lib/bm25_search.py
@@ -1,0 +1,58 @@
+"""Utilities for BM25 search over code chunks."""
+
+import re
+from typing import TYPE_CHECKING, Sequence
+
+import numpy as np
+from rank_bm25 import BM25Okapi
+
+if TYPE_CHECKING:
+    import polars as pl
+
+
+def _tokenize(text: str) -> list[str]:
+    """Return lowercase word tokens from *text*."""
+    return re.findall(r"\w+", text.lower())
+
+
+def bm25_search(query: str, df: "pl.DataFrame", threshold_ratio: float = 0.5) -> list[dict[str, str]]:
+    """Rank *df* code chunks by relevance to *query* using BM25.
+
+    All results scoring below ``threshold_ratio`` times the best match are
+    discarded. Empirically, BM25 scores drop off quickly; keeping only
+    chunks within 50% of the top score filters out weak matches while
+    still returning multiple strong candidates.
+    """
+
+    documents: list[list[str]] = []
+    for row in df.iter_rows(named=True):
+        # Emphasize function name and docstring for better relevance
+        weighted_text = f"{row['name']} {row['name']} {row['docstring']} {row['docstring']} {row['code']}"
+        documents.append(_tokenize(weighted_text))
+
+    if not documents:
+        return []
+
+    bm25 = BM25Okapi(documents)
+    query_tokens = _tokenize(query)
+    scores = bm25.get_scores(query_tokens) if query_tokens else np.zeros(len(documents))
+    max_score = float(np.max(scores)) if len(scores) else 0.0
+    if max_score <= 0:
+        return []
+
+    cutoff = max_score * threshold_ratio
+    ranked_idx = np.argsort(scores)[::-1]
+    results = []
+    for i in ranked_idx:
+        if scores[i] < cutoff:
+            break
+        results.append(df.row(int(i), named=True))
+    return results
+
+
+def build_context(chunks: Sequence[dict[str, str]]) -> str:
+    """Build a context string from ranked *chunks*."""
+    parts = []
+    for c in chunks:
+        parts.append(f"{c['full_name']}\n{c['code']}")
+    return "\n\n".join(parts)

--- a/src/lib/streamlit_helper.py
+++ b/src/lib/streamlit_helper.py
@@ -74,6 +74,9 @@ def init_session_state() -> None:
         st.session_state.client = OpenAIBaseClient(st.session_state.selected_model)
         st.session_state.client.set_system_prompt(SYS_LEARNING_MATERIAL)
 
+    if "context_enabled" not in st.session_state:
+        st.session_state.context_enabled = False
+
 
 def application_side_bar() -> None:
     model = st.sidebar.selectbox(
@@ -103,6 +106,12 @@ def application_side_bar() -> None:
         st.session_state.selected_repo = str(repo)
     else:
         st.sidebar.info("No Git repositories found")
+
+    st.session_state.context_enabled = st.sidebar.checkbox(
+        "Enable context aware chat",
+        value=st.session_state.context_enabled,
+        key="context_checkbox",
+    )
 
 
 def render_messages(message_container) -> None:  # noqa


### PR DESCRIPTION
## Summary
- integrate rank-bm25 for code retrieval and drop fixed top-k in favor of a score-based cutoff
- inject retrieved context into the user message within the chat interface instead of the OpenAI client
- add sidebar checkbox to enable context-aware chat
- provide BM25 retrieval test tab showing the matching code chunks DataFrame without invoking the LLM
- add rank-bm25 dependency for BM25 search

## Testing
- `ruff check src/main.py src/openai_client.py src/lib/streamlit_helper.py src/lib/bm25_search.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa5bec32288331aeb8e4cd0127a29b